### PR TITLE
fileNameArg in ExtractFileNameFromUriResolver

### DIFF
--- a/Flow.Mapping/Resolvers/ExtractFileNameFromUriResolver.cs
+++ b/Flow.Mapping/Resolvers/ExtractFileNameFromUriResolver.cs
@@ -42,6 +42,18 @@ public class ExtractFileNameFromUriResolver : IFlowValueResolver
             }
         }
 
+        if (context.ValueResolverArguments != null && context.ValueResolverArguments.Any())
+        {
+            foreach (var resolver in context.ValueResolverArguments)
+            {
+                if (resolver.Name == "fileNameArg" && !string.IsNullOrEmpty(resolver.Value))
+                {
+                    var queryParams = HttpUtility.ParseQueryString(uri.Query);
+                    return queryParams[resolver.Value];
+                }
+            }
+        }
+
         var fileName = text;
         if (uri != null && !string.IsNullOrEmpty(uri.AbsolutePath))
         {


### PR DESCRIPTION
Les resolver ExtractFileNameFromUriResolver peut maintenant gérer les url qui possèdent des arguments qui sont le nom de fichier recherché